### PR TITLE
Add waving student avatar, Digital Brain project, and stack icons

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,17 +2,20 @@
     const root = document.documentElement;
     const storageKey = 'cv-theme';
     const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+    /* ---------- Theme ---------- */
     const saved = localStorage.getItem(storageKey);
-    const initial = saved || (media.matches ? 'dark' : 'light');
-    root.setAttribute('data-theme', initial);
+    root.setAttribute('data-theme', saved || (media.matches ? 'dark' : 'light'));
 
     const btn = document.getElementById('theme-toggle');
     if (btn) {
         btn.addEventListener('click', () => {
+            root.classList.add('theme-fade');
             const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
             root.setAttribute('data-theme', next);
             localStorage.setItem(storageKey, next);
+            setTimeout(() => root.classList.remove('theme-fade'), 400);
         });
     }
 
@@ -22,6 +25,64 @@
         }
     });
 
+    /* ---------- Footer year ---------- */
     const yearEl = document.getElementById('year');
     if (yearEl) yearEl.textContent = new Date().getFullYear();
+
+    /* ---------- Reading progress + header shadow ---------- */
+    const progress = document.getElementById('progress');
+    const header = document.querySelector('.site-header');
+    let ticking = false;
+
+    function onScroll() {
+        if (ticking) return;
+        ticking = true;
+        requestAnimationFrame(() => {
+            const doc = document.documentElement;
+            const max = doc.scrollHeight - doc.clientHeight;
+            if (progress) progress.style.width = (max > 0 ? (doc.scrollTop / max) * 100 : 0) + '%';
+            if (header) header.classList.toggle('scrolled', doc.scrollTop > 8);
+            ticking = false;
+        });
+    }
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+
+    /* ---------- Scroll reveal ---------- */
+    const revealTargets = document.querySelectorAll('.entry, .skills, ul.plain, .footer-title');
+    if (!reducedMotion && 'IntersectionObserver' in window) {
+        const revealObserver = new IntersectionObserver((items) => {
+            items.forEach((item) => {
+                if (item.isIntersecting) {
+                    item.target.classList.add('visible');
+                    revealObserver.unobserve(item.target);
+                }
+            });
+        }, { rootMargin: '0px 0px -8% 0px', threshold: 0.05 });
+
+        revealTargets.forEach((el) => {
+            el.classList.add('reveal');
+            revealObserver.observe(el);
+        });
+    }
+
+    /* ---------- Active nav link ---------- */
+    const navLinks = Array.from(document.querySelectorAll('.site-header nav a[href^="#"]'));
+    const sections = navLinks
+        .map((a) => document.querySelector(a.getAttribute('href')))
+        .filter(Boolean);
+
+    if (sections.length && 'IntersectionObserver' in window) {
+        const navObserver = new IntersectionObserver((items) => {
+            items.forEach((item) => {
+                if (item.isIntersecting) {
+                    navLinks.forEach((a) =>
+                        a.classList.toggle('active', a.getAttribute('href') === '#' + item.target.id)
+                    );
+                }
+            });
+        }, { rootMargin: '-30% 0px -60% 0px' });
+
+        sections.forEach((s) => navObserver.observe(s));
+    }
 })();

--- a/index.html
+++ b/index.html
@@ -38,12 +38,54 @@
 
         <section id="intro" class="intro">
             <p class="status"><span class="dot"></span>Currently — LLM Research Engineer&nbsp;@&nbsp;Predii</p>
+            <div class="intro-grid">
+            <div class="intro-text">
             <h1>C. Viswanath</h1>
             <p class="lede">
                 LLM Research Engineer at <a href="https://www.predii.com" target="_blank" rel="noopener">Predii</a> and
                 MS&nbsp;by&nbsp;Research student at <a href="https://www.iiitb.ac.in" target="_blank" rel="noopener">IIIT Bangalore</a>.
                 I work on multilingual and agentic language models — currently on vision-LLM extraction, retrieval systems, and the mechanistic evaluation of <em class="accent-em">cultural understanding</em> in LLMs.
             </p>
+            </div>
+            <div class="avatar-wrap" aria-hidden="false">
+                <svg class="avatar" viewBox="0 0 240 250" role="img" aria-label="Cartoon student character waving hi">
+                    <g class="bubble">
+                        <rect x="158" y="14" rx="15" ry="15" width="66" height="38" class="bubble-bg"/>
+                        <path d="M176 51 l5 13 11-11 z" class="bubble-bg"/>
+                        <text x="191" y="40" class="bubble-text">hi!</text>
+                    </g>
+                    <g class="arm-wave">
+                        <path d="M150 162 Q176 148 184 122" class="sleeve"/>
+                        <circle cx="185" cy="114" r="10" class="skin"/>
+                    </g>
+                    <path d="M72 212 q0 -54 48 -54 q48 0 48 54 z" class="sweater"/>
+                    <path d="M86 172 q-14 18 -9 34" class="sleeve"/>
+                    <circle cx="79" cy="209" r="9" class="skin"/>
+                    <rect x="108" y="140" width="24" height="16" rx="7" class="skin"/>
+                    <g class="head">
+                        <circle cx="76" cy="106" r="7" class="skin"/>
+                        <circle cx="164" cy="106" r="7" class="skin"/>
+                        <circle cx="120" cy="102" r="44" class="skin"/>
+                        <path d="M76 98 q2 -46 44 -46 q42 0 44 46 q-7 -20 -22 -24 q5 8 3 13 q-11 -15 -35 -13 q-26 2 -34 24 z" class="hair"/>
+                        <circle cx="103" cy="108" r="13" class="glass"/>
+                        <circle cx="137" cy="108" r="13" class="glass"/>
+                        <path d="M116 108 h8" class="glass"/>
+                        <circle cx="103" cy="108" r="3.4" class="eye"/>
+                        <circle cx="137" cy="108" r="3.4" class="eye"/>
+                        <path d="M108 128 q12 10 24 0" class="smile"/>
+                        <ellipse cx="90" cy="124" rx="5" ry="3" class="blush"/>
+                        <ellipse cx="150" cy="124" rx="5" ry="3" class="blush"/>
+                        <g class="cap">
+                            <path d="M120 34 L174 56 L120 78 L66 56 Z" class="cap-top"/>
+                            <path d="M98 64 v14 q22 11 44 0 v-14" class="cap-base"/>
+                            <path d="M174 56 v24" class="tassel-string"/>
+                            <circle cx="174" cy="84" r="5" class="tassel"/>
+                        </g>
+                    </g>
+                    <ellipse cx="120" cy="222" rx="58" ry="7" class="ground"/>
+                </svg>
+            </div>
+            </div>
             <ul class="meta">
                 <li>Bangalore, IN</li>
                 <li><a href="mailto:cvishwanath1417@gmail.com">cvishwanath1417@gmail.com</a></li>
@@ -168,7 +210,43 @@
                         <li>Twelve-microservice LangGraph orchestrator with 92% eval pass rate, DEPA-style consent gate, PII encryption and full audit trail on GKE.</li>
                         <li>Stateful conversations handling interruptions, context switches and database-backed scheme validation in real time.</li>
                     </ul>
-                    <p class="tags"><span>Python</span><span>FastAPI</span><span>LangGraph</span><span>Claude Sonnet</span><span>PostgreSQL</span><span>Docker</span><span>GKE</span></p>
+                    <p class="tags">
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/python')"></i>Python</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/fastapi')"></i>FastAPI</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/langgraph')"></i>LangGraph</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/claude')"></i>Claude Sonnet</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/postgresql')"></i>PostgreSQL</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/docker')"></i>Docker</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/googlecloud')"></i>GKE</span>
+                    </p>
+                </article>
+
+                <article class="entry card">
+                    <a class="card-cta" href="https://brain.madebycv.in" target="_blank" rel="noopener">Open live demo →</a>
+                    <div class="entry-head">
+                        <div>
+                            <h3>Digital Brain — Personal Life OS</h3>
+                            <p class="org">Routine, habits, work board, journal &amp; meditation in one place</p>
+                        </div>
+                        <span class="date">
+                            <a href="https://brain.madebycv.in" target="_blank" rel="noopener">Live&nbsp;↗</a> · <a href="https://github.com/c-viswanath/digital-brain" target="_blank" rel="noopener">GitHub&nbsp;↗</a>
+                        </span>
+                    </div>
+                    <ul>
+                        <li>Single-user "life OS" — daily routine, habit streaks, kanban work board, journal, meditation and discipline log, with Google Calendar sync.</li>
+                        <li>Next.js 16 + Supabase (Postgres, row-level security, auth) PWA deployed on Vercel at <a href="https://brain.madebycv.in" target="_blank" rel="noopener">brain.madebycv.in</a>.</li>
+                        <li>LLM-powered dynamic greeting and accountability nudges via GPT-4o-mini, with a local Ollama fallback for dev.</li>
+                    </ul>
+                    <p class="tags">
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/nextdotjs')"></i>Next.js</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/typescript')"></i>TypeScript</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/supabase')"></i>Supabase</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/tailwindcss')"></i>Tailwind v4</span>
+                        <span>GPT-4o-mini</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/ollama')"></i>Ollama</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/vercel')"></i>Vercel</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/googlecalendar')"></i>Google Calendar</span>
+                    </p>
                 </article>
 
                 <article class="entry card">
@@ -184,7 +262,14 @@
                         <li>Integrated EHR/EMR devices via REST and FHIR pipelines for real-time data ingestion on GCP.</li>
                         <li>HIPAA-compliant BigQuery and Firebase schemas with field-level encryption for sensitive EHR records.</li>
                     </ul>
-                    <p class="tags"><span>Gemini API</span><span>GCP</span><span>Cloud Run</span><span>Firebase</span><span>BigQuery</span><span>FHIR</span></p>
+                    <p class="tags">
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/googlegemini')"></i>Gemini API</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/googlecloud')"></i>GCP</span>
+                        <span>Cloud Run</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/firebase')"></i>Firebase</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/googlebigquery')"></i>BigQuery</span>
+                        <span>FHIR</span>
+                    </p>
                 </article>
 
                 <article class="entry card">
@@ -201,7 +286,11 @@
                         <li>Enforces explicit colour palettes in diffusion outputs by encoding dominant CIELAB colours as conditioning maps.</li>
                         <li>Improved colour fidelity without sacrificing visual quality — useful for product photography.</li>
                     </ul>
-                    <p class="tags"><span>PyTorch</span><span>Diffusion Models</span><span>ControlNet</span></p>
+                    <p class="tags">
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/pytorch')"></i>PyTorch</span>
+                        <span>Diffusion Models</span>
+                        <span>ControlNet</span>
+                    </p>
                 </article>
 
             </div>

--- a/index.html
+++ b/index.html
@@ -16,16 +16,19 @@
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90' font-family='serif'%3ECv%3C/text%3E%3C/svg%3E">
 </head>
 <body>
+    <div id="progress" aria-hidden="true"></div>
+
     <header class="site-header">
         <div class="wrap">
-            <a href="#" class="brand">C. Viswanath</a>
+            <a href="#" class="brand">C.&nbsp;Viswanath</a>
             <nav>
                 <a href="#work">Work</a>
                 <a href="#research">Research</a>
                 <a href="#projects">Projects</a>
                 <a href="#education">Education</a>
                 <button id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                    <svg class="icon-moon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                    <svg class="icon-sun" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M4.93 4.93l1.41 1.41m11.32 11.32 1.41 1.41M2 12h2m16 0h2M4.93 19.07l1.41-1.41m11.32-11.32 1.41-1.41"/></svg>
                 </button>
             </nav>
         </div>
@@ -34,11 +37,12 @@
     <main class="wrap">
 
         <section id="intro" class="intro">
+            <p class="status"><span class="dot"></span>Currently — LLM Research Engineer&nbsp;@&nbsp;Predii</p>
             <h1>C. Viswanath</h1>
             <p class="lede">
                 LLM Research Engineer at <a href="https://www.predii.com" target="_blank" rel="noopener">Predii</a> and
                 MS&nbsp;by&nbsp;Research student at <a href="https://www.iiitb.ac.in" target="_blank" rel="noopener">IIIT Bangalore</a>.
-                I work on multilingual and agentic language models — currently on vision-LLM extraction, retrieval systems, and the mechanistic evaluation of cultural understanding in LLMs.
+                I work on multilingual and agentic language models — currently on vision-LLM extraction, retrieval systems, and the mechanistic evaluation of <em class="accent-em">cultural understanding</em> in LLMs.
             </p>
             <ul class="meta">
                 <li>Bangalore, IN</li>
@@ -46,13 +50,13 @@
                 <li><a href="https://github.com/c-viswanath" target="_blank" rel="noopener">GitHub</a></li>
                 <li><a href="https://www.linkedin.com/in/c-vishwanath-7b9791175/" target="_blank" rel="noopener">LinkedIn</a></li>
                 <li><a href="https://twitter.com/vishwacodes" target="_blank" rel="noopener">Twitter</a></li>
-                <li><a href="assets/C-Viswanath-CV.pdf" target="_blank" rel="noopener">CV&nbsp;↗</a></li>
+                <li><a href="assets/C-Viswanath-CV.pdf" target="_blank" rel="noopener" class="cv-link">CV&nbsp;↗</a></li>
             </ul>
         </section>
 
         <section id="work" class="section">
             <h2>Experience</h2>
-            <div class="entries">
+            <div class="entries timeline">
 
                 <article class="entry">
                     <div class="entry-head">
@@ -100,7 +104,7 @@
 
         <section id="research" class="section">
             <h2>Research</h2>
-            <div class="entries">
+            <div class="entries timeline">
 
                 <article class="entry">
                     <div class="entry-head">
@@ -147,9 +151,9 @@
 
         <section id="projects" class="section">
             <h2>Selected Projects</h2>
-            <div class="entries">
+            <div class="entries cards">
 
-                <article class="entry">
+                <article class="entry card">
                     <div class="entry-head">
                         <div>
                             <h3>JanMitra — Voice-First Agentic AI</h3>
@@ -164,10 +168,10 @@
                         <li>Twelve-microservice LangGraph orchestrator with 92% eval pass rate, DEPA-style consent gate, PII encryption and full audit trail on GKE.</li>
                         <li>Stateful conversations handling interruptions, context switches and database-backed scheme validation in real time.</li>
                     </ul>
-                    <p class="tags">Python · FastAPI · LangGraph · Claude Sonnet · PostgreSQL · Docker · GKE</p>
+                    <p class="tags"><span>Python</span><span>FastAPI</span><span>LangGraph</span><span>Claude Sonnet</span><span>PostgreSQL</span><span>Docker</span><span>GKE</span></p>
                 </article>
 
-                <article class="entry">
+                <article class="entry card">
                     <div class="entry-head">
                         <div>
                             <h3>Full-Stack Health QA System</h3>
@@ -180,10 +184,10 @@
                         <li>Integrated EHR/EMR devices via REST and FHIR pipelines for real-time data ingestion on GCP.</li>
                         <li>HIPAA-compliant BigQuery and Firebase schemas with field-level encryption for sensitive EHR records.</li>
                     </ul>
-                    <p class="tags">Gemini API · GCP · Cloud Run · Firebase · BigQuery · FHIR</p>
+                    <p class="tags"><span>Gemini API</span><span>GCP</span><span>Cloud Run</span><span>Firebase</span><span>BigQuery</span><span>FHIR</span></p>
                 </article>
 
-                <article class="entry">
+                <article class="entry card">
                     <div class="entry-head">
                         <div>
                             <h3>Palette-Conditioned ControlNet</h3>
@@ -197,7 +201,7 @@
                         <li>Enforces explicit colour palettes in diffusion outputs by encoding dominant CIELAB colours as conditioning maps.</li>
                         <li>Improved colour fidelity without sacrificing visual quality — useful for product photography.</li>
                     </ul>
-                    <p class="tags">PyTorch · Diffusion Models · ControlNet</p>
+                    <p class="tags"><span>PyTorch</span><span>Diffusion Models</span><span>ControlNet</span></p>
                 </article>
 
             </div>
@@ -206,7 +210,7 @@
 
         <section id="education" class="section">
             <h2>Education</h2>
-            <div class="entries">
+            <div class="entries timeline">
 
                 <article class="entry compact">
                     <div class="entry-head">
@@ -233,7 +237,7 @@
         </section>
 
         <section id="skills" class="section">
-            <h2>Skills & Tools</h2>
+            <h2>Skills &amp; Tools</h2>
             <dl class="skills">
                 <dt>AI &amp; ML</dt>
                 <dd>NLP · Generative AI · LLMs · RAG · Multimodal Models · Agentic Systems</dd>
@@ -262,7 +266,8 @@
         </section>
 
         <footer class="footer">
-            <p>Get in touch — <a href="mailto:cvishwanath1417@gmail.com">cvishwanath1417@gmail.com</a></p>
+            <h2 class="footer-title">Get in touch<span class="accent-dot">.</span></h2>
+            <p><a class="footer-mail" href="mailto:cvishwanath1417@gmail.com">cvishwanath1417@gmail.com <span class="arrow">→</span></a></p>
             <p class="fine">© <span id="year"></span> C. Viswanath · Built with plain HTML &amp; CSS</p>
         </footer>
 

--- a/style.css
+++ b/style.css
@@ -7,6 +7,8 @@
     --accent-soft: #E9EEF7;
     --rule: #E7E3D8;
     --tag: #F3F0E7;
+    --glow: rgba(42, 75, 141, 0.10);
+    --ok: #3E8E5A;
     --serif: 'Instrument Serif', 'EB Garamond', Georgia, serif;
     --sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
@@ -21,6 +23,8 @@
     --accent-soft: #1F2A44;
     --rule: #2B2A22;
     --tag: #23221C;
+    --glow: rgba(158, 184, 233, 0.12);
+    --ok: #6FBF8A;
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -38,13 +42,42 @@ body {
     font-feature-settings: "ss01", "cv11";
 }
 
+/* Film-grain texture */
+body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    pointer-events: none;
+    opacity: .028;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+[data-theme="dark"] body::after { opacity: .05; }
+
+/* Smooth theme change */
+html.theme-fade body,
+html.theme-fade .site-header,
+html.theme-fade .card,
+html.theme-fade .tags span {
+    transition: background-color .35s ease, color .35s ease, border-color .35s ease;
+}
+
 a {
     color: var(--accent);
     text-decoration: none;
-    border-bottom: 1px solid transparent;
-    transition: border-color .15s ease, color .15s ease;
 }
-a:hover { border-bottom-color: var(--accent); }
+
+/* Animated underline for in-text links */
+.lede a, .entry a, .meta a, .see-more a, ul.plain a {
+    background-image: linear-gradient(currentColor, currentColor);
+    background-size: 0% 1px;
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    transition: background-size .25s ease, color .15s ease;
+}
+.lede a:hover, .entry a:hover, .meta a:hover, .see-more a:hover, ul.plain a:hover {
+    background-size: 100% 1px;
+}
 
 ::selection { background: var(--accent-soft); color: var(--text); }
 
@@ -54,14 +87,31 @@ a:hover { border-bottom-color: var(--accent); }
     padding: 0 24px;
 }
 
+/* ---------- Reading progress ---------- */
+#progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 2px;
+    width: 0;
+    z-index: 100;
+    background: linear-gradient(90deg, var(--accent), color-mix(in oklab, var(--accent) 55%, var(--bg)));
+}
+
 /* ---------- Header ---------- */
 .site-header {
     position: sticky;
     top: 0;
     z-index: 10;
-    background: color-mix(in oklab, var(--bg) 92%, transparent);
-    backdrop-filter: saturate(1.4) blur(10px);
-    border-bottom: 1px solid var(--rule);
+    background: color-mix(in oklab, var(--bg) 88%, transparent);
+    backdrop-filter: saturate(1.4) blur(12px);
+    -webkit-backdrop-filter: saturate(1.4) blur(12px);
+    border-bottom: 1px solid transparent;
+    transition: border-color .3s ease, box-shadow .3s ease;
+}
+.site-header.scrolled {
+    border-bottom-color: var(--rule);
+    box-shadow: 0 6px 24px -18px rgba(0, 0, 0, .35);
 }
 .site-header .wrap {
     display: flex;
@@ -75,7 +125,7 @@ a:hover { border-bottom-color: var(--accent); }
     font-size: 20px;
     letter-spacing: .01em;
     color: var(--text);
-    border-bottom: none;
+    transition: color .15s ease;
 }
 .brand:hover { color: var(--accent); }
 
@@ -85,14 +135,30 @@ a:hover { border-bottom-color: var(--accent); }
     gap: 22px;
 }
 .site-header nav a {
+    position: relative;
     color: var(--muted);
     font-size: 14px;
     font-weight: 500;
-    border-bottom: none;
+    transition: color .15s ease;
+}
+.site-header nav a::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -4px;
+    width: 100%;
+    height: 1px;
+    background: var(--accent);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform .25s ease;
 }
 .site-header nav a:hover { color: var(--text); }
+.site-header nav a.active { color: var(--text); }
+.site-header nav a.active::after { transform: scaleX(1); }
 
 #theme-toggle {
+    position: relative;
     background: transparent;
     border: 1px solid var(--rule);
     color: var(--muted);
@@ -101,21 +167,74 @@ a:hover { border-bottom-color: var(--accent); }
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border-radius: 6px;
+    border-radius: 8px;
     cursor: pointer;
-    transition: color .15s ease, border-color .15s ease;
+    overflow: hidden;
+    transition: color .15s ease, border-color .15s ease, transform .15s ease;
 }
 #theme-toggle:hover { color: var(--text); border-color: var(--muted); }
+#theme-toggle:active { transform: scale(.92); }
+#theme-toggle svg {
+    position: absolute;
+    transition: transform .4s cubic-bezier(.34, 1.56, .64, 1), opacity .25s ease;
+}
+#theme-toggle .icon-sun { opacity: 0; transform: rotate(90deg) scale(.4); }
+#theme-toggle .icon-moon { opacity: 1; transform: rotate(0) scale(1); }
+[data-theme="dark"] #theme-toggle .icon-sun { opacity: 1; transform: rotate(0) scale(1); }
+[data-theme="dark"] #theme-toggle .icon-moon { opacity: 0; transform: rotate(-90deg) scale(.4); }
 
 /* ---------- Intro ---------- */
 .intro {
-    padding: 72px 0 24px;
+    position: relative;
+    padding: 76px 0 30px;
     border-bottom: 1px solid var(--rule);
 }
+.intro::before {
+    content: 'Cv';
+    position: absolute;
+    top: 8px;
+    right: -40px;
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 300px;
+    line-height: 1;
+    color: var(--text);
+    opacity: .035;
+    pointer-events: none;
+    user-select: none;
+}
+
+.status {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--muted);
+    border: 1px solid var(--rule);
+    background: var(--surface);
+    border-radius: 999px;
+    padding: 5px 14px;
+    margin-bottom: 26px;
+}
+.status .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--ok);
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--ok) 45%, transparent);
+    animation: pulse 2.4s ease-out infinite;
+}
+@keyframes pulse {
+    0% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--ok) 45%, transparent); }
+    70% { box-shadow: 0 0 0 7px transparent; }
+    100% { box-shadow: 0 0 0 0 transparent; }
+}
+
 .intro h1 {
     font-family: var(--serif);
     font-weight: 400;
-    font-size: 52px;
+    font-size: 56px;
     line-height: 1.05;
     letter-spacing: -.01em;
     margin-bottom: 20px;
@@ -126,6 +245,12 @@ a:hover { border-bottom-color: var(--accent); }
     color: var(--text);
     max-width: 64ch;
     margin-bottom: 22px;
+}
+.accent-em {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 1.08em;
+    color: var(--accent);
 }
 .meta {
     list-style: none;
@@ -143,20 +268,43 @@ a:hover { border-bottom-color: var(--accent); }
     color: var(--rule);
 }
 .meta a { color: var(--muted); }
-.meta a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+.meta a:hover { color: var(--accent); }
+.meta .cv-link {
+    color: var(--accent);
+    font-weight: 500;
+}
 
 /* ---------- Sections ---------- */
-.section { padding: 48px 0; border-bottom: 1px solid var(--rule); }
+main.wrap { counter-reset: sec; }
+
+.section { padding: 52px 0; border-bottom: 1px solid var(--rule); }
 .section:last-of-type { border-bottom: none; }
 
 .section h2 {
+    display: flex;
+    align-items: center;
+    gap: 14px;
     font-family: var(--sans);
     font-weight: 500;
     font-size: 12px;
     letter-spacing: .16em;
     text-transform: uppercase;
     color: var(--muted);
-    margin-bottom: 28px;
+    margin-bottom: 30px;
+    counter-increment: sec;
+}
+.section h2::before {
+    content: counter(sec, decimal-leading-zero);
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--accent);
+    letter-spacing: 0;
+}
+.section h2::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--rule);
 }
 
 .section h3.minor {
@@ -170,7 +318,33 @@ a:hover { border-bottom-color: var(--accent); }
 }
 
 /* ---------- Entries ---------- */
-.entries { display: flex; flex-direction: column; gap: 32px; }
+.entries { display: flex; flex-direction: column; gap: 30px; }
+
+/* Timeline treatment (work / research / education) */
+.timeline .entry {
+    position: relative;
+    padding-left: 24px;
+    border-left: 1px solid var(--rule);
+    transition: border-color .25s ease;
+}
+.timeline .entry::before {
+    content: '';
+    position: absolute;
+    left: -4.5px;
+    top: 8px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--bg);
+    border: 1.5px solid var(--muted);
+    transition: background .25s ease, border-color .25s ease, box-shadow .25s ease;
+}
+.timeline .entry:hover { border-left-color: var(--accent); }
+.timeline .entry:hover::before {
+    background: var(--accent);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 4px var(--glow);
+}
 
 .entry-head {
     display: flex;
@@ -191,8 +365,8 @@ a:hover { border-bottom-color: var(--accent); }
     color: var(--muted);
     margin-top: 2px;
 }
-.entry .org a { color: var(--muted); border-bottom-color: var(--rule); }
-.entry .org a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+.entry .org a { color: var(--muted); }
+.entry .org a:hover { color: var(--accent); }
 
 .entry .date {
     font-family: var(--mono);
@@ -201,8 +375,7 @@ a:hover { border-bottom-color: var(--accent); }
     white-space: nowrap;
     flex-shrink: 0;
 }
-.entry .date a { color: var(--muted); border-bottom: none; }
-.entry .date a:hover { color: var(--accent); }
+.entry .date a { color: var(--accent); }
 
 .entry ul {
     list-style: none;
@@ -229,13 +402,42 @@ a:hover { border-bottom-color: var(--accent); }
 
 .entry.compact ul { display: none; }
 
-.tags {
-    margin-top: 12px;
-    font-family: var(--mono);
-    font-size: 12px;
-    color: var(--muted);
-    letter-spacing: .01em;
+/* Project cards */
+.cards .entry.card {
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: 14px;
+    padding: 26px 28px;
+    transition: transform .3s cubic-bezier(.2, .8, .3, 1), box-shadow .3s ease, border-color .3s ease;
 }
+.cards .entry.card:hover {
+    transform: translateY(-4px);
+    border-color: color-mix(in oklab, var(--accent) 45%, var(--rule));
+    box-shadow: 0 18px 40px -24px rgba(0, 0, 0, .35), 0 0 0 4px var(--glow);
+}
+
+.tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 14px;
+}
+.tags span {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: .01em;
+    color: var(--muted);
+    background: var(--tag);
+    border: 1px solid var(--rule);
+    border-radius: 999px;
+    padding: 3px 10px;
+    transition: color .2s ease, border-color .2s ease;
+}
+.cards .entry.card:hover .tags span {
+    color: var(--text);
+    border-color: color-mix(in oklab, var(--accent) 30%, var(--rule));
+}
+
 .coursework {
     margin-top: 6px;
     font-size: 14px;
@@ -276,31 +478,73 @@ ul.plain li strong { font-weight: 600; }
 
 /* ---------- Footer ---------- */
 .footer {
-    padding: 56px 0 72px;
-    text-align: left;
+    padding: 64px 0 80px;
     font-size: 14px;
     color: var(--muted);
 }
-.footer p + p { margin-top: 8px; }
-.footer .fine { font-size: 12px; color: var(--muted); }
+.footer-title {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 44px;
+    color: var(--text);
+    margin-bottom: 14px;
+}
+.accent-dot { color: var(--accent); }
+.footer-mail {
+    font-family: var(--mono);
+    font-size: 15px;
+    color: var(--accent);
+}
+.footer-mail .arrow {
+    display: inline-block;
+    transition: transform .25s ease;
+}
+.footer-mail:hover .arrow { transform: translateX(6px); }
+.footer .fine { margin-top: 28px; font-size: 12px; color: var(--muted); }
+
+/* ---------- Scroll reveal ---------- */
+.reveal {
+    opacity: 0;
+    transform: translateY(18px);
+    transition: opacity .6s ease, transform .6s cubic-bezier(.2, .8, .3, 1);
+}
+.reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* ---------- Scrollbar ---------- */
+::-webkit-scrollbar { width: 10px; }
+::-webkit-scrollbar-track { background: var(--bg); }
+::-webkit-scrollbar-thumb {
+    background: var(--rule);
+    border-radius: 5px;
+    border: 2px solid var(--bg);
+}
+::-webkit-scrollbar-thumb:hover { background: var(--muted); }
 
 /* ---------- Responsive ---------- */
 @media (max-width: 640px) {
     .wrap { padding: 0 20px; }
-    .intro { padding: 48px 0 20px; }
+    .intro { padding: 48px 0 24px; }
+    .intro::before { font-size: 180px; right: -30px; }
     .intro h1 { font-size: 40px; }
     .lede { font-size: 16px; }
     .section { padding: 40px 0; }
     .entry-head { flex-direction: column; gap: 4px; align-items: flex-start; }
     .entry .date { font-size: 11px; }
     .entry h3 { font-size: 20px; }
+    .cards .entry.card { padding: 20px; }
+    .timeline .entry { padding-left: 18px; }
     .skills { grid-template-columns: 1fr; row-gap: 4px; }
     .skills dt { margin-top: 12px; }
+    .footer-title { font-size: 34px; }
     .site-header nav { gap: 14px; }
-    .site-header nav a:not(#theme-toggle) { display: none; }
+    .site-header nav a { display: none; }
     .site-header nav a[href="#work"], .site-header nav a[href="#research"] { display: inline; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-    * { transition: none !important; scroll-behavior: auto; }
+    * { transition: none !important; animation: none !important; scroll-behavior: auto; }
+    .reveal { opacity: 1; transform: none; }
 }

--- a/style.css
+++ b/style.css
@@ -231,6 +231,14 @@ a {
     100% { box-shadow: 0 0 0 0 transparent; }
 }
 
+.intro-grid {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 28px;
+}
+.intro-text { flex: 1; min-width: 0; }
+
 .intro h1 {
     font-family: var(--serif);
     font-weight: 400;
@@ -238,6 +246,80 @@ a {
     line-height: 1.05;
     letter-spacing: -.01em;
     margin-bottom: 20px;
+}
+
+/* ---------- Avatar ---------- */
+.avatar-wrap {
+    flex-shrink: 0;
+    width: 200px;
+}
+.avatar { width: 100%; height: auto; display: block; }
+
+.avatar .skin { fill: #E0A971; }
+.avatar .hair { fill: #241C14; }
+.avatar .sweater { fill: var(--accent); }
+.avatar .sleeve {
+    fill: none;
+    stroke: var(--accent);
+    stroke-width: 14;
+    stroke-linecap: round;
+}
+.avatar .glass {
+    fill: rgba(255, 255, 255, .16);
+    stroke: var(--text);
+    stroke-width: 2.5;
+}
+.avatar .eye { fill: #1A1A1A; transform-box: fill-box; transform-origin: center; }
+[data-theme="dark"] .avatar .eye { fill: #14140F; }
+.avatar .smile {
+    fill: none;
+    stroke: #8C5A33;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+}
+.avatar .blush { fill: rgba(214, 108, 91, .35); }
+.avatar .cap-top { fill: #23231E; stroke: var(--rule); stroke-width: 1; }
+.avatar .cap-base { fill: #2E2E27; }
+.avatar .tassel-string { stroke: #D9A93F; stroke-width: 2; fill: none; }
+.avatar .tassel { fill: #D9A93F; }
+.avatar .ground { fill: rgba(0, 0, 0, .08); }
+[data-theme="dark"] .avatar .ground { fill: rgba(0, 0, 0, .35); }
+.avatar .bubble-bg { fill: var(--surface); stroke: var(--rule); stroke-width: 1.5; }
+.avatar .bubble-text {
+    font-family: var(--mono);
+    font-size: 19px;
+    fill: var(--accent);
+    text-anchor: middle;
+}
+
+.avatar .arm-wave {
+    transform-origin: 150px 160px;
+    animation: wave 1.9s ease-in-out infinite;
+}
+@keyframes wave {
+    0%, 100% { transform: rotate(10deg); }
+    50% { transform: rotate(-16deg); }
+}
+.avatar .head {
+    transform-origin: 120px 148px;
+    animation: head-tilt 5.6s ease-in-out infinite;
+}
+@keyframes head-tilt {
+    0%, 100% { transform: rotate(-1.6deg); }
+    50% { transform: rotate(2.2deg); }
+}
+.avatar .eye { animation: blink 4.4s infinite; }
+@keyframes blink {
+    0%, 91%, 96%, 100% { transform: scaleY(1); }
+    93.5% { transform: scaleY(.08); }
+}
+.avatar .bubble {
+    transform-origin: 190px 44px;
+    animation: bubble-bob 1.9s ease-in-out infinite;
+}
+@keyframes bubble-bob {
+    0%, 100% { transform: translateY(0) scale(1); }
+    50% { transform: translateY(-4px) scale(1.05); }
 }
 .lede {
     font-size: 18px;
@@ -423,6 +505,9 @@ main.wrap { counter-reset: sec; }
     margin-top: 14px;
 }
 .tags span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     font-family: var(--mono);
     font-size: 11px;
     letter-spacing: .01em;
@@ -433,9 +518,43 @@ main.wrap { counter-reset: sec; }
     padding: 3px 10px;
     transition: color .2s ease, border-color .2s ease;
 }
+.tags .ti {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+    background-color: currentColor;
+    -webkit-mask: var(--i) center / contain no-repeat;
+    mask: var(--i) center / contain no-repeat;
+}
 .cards .entry.card:hover .tags span {
     color: var(--text);
     border-color: color-mix(in oklab, var(--accent) 30%, var(--rule));
+}
+
+/* Hover CTA (live demo) */
+.card-cta {
+    position: absolute;
+    right: 20px;
+    bottom: 20px;
+    z-index: 2;
+    font-family: var(--mono);
+    font-size: 12px;
+    padding: 7px 14px;
+    border-radius: 999px;
+    background: var(--accent);
+    color: var(--bg);
+    opacity: 0;
+    transform: translateY(8px);
+    pointer-events: none;
+    transition: opacity .25s ease, transform .25s cubic-bezier(.2, .8, .3, 1);
+    box-shadow: 0 10px 24px -12px var(--glow);
+}
+.cards .entry.card:hover .card-cta,
+.card-cta:focus-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
 }
 
 .coursework {
@@ -528,6 +647,8 @@ ul.plain li strong { font-weight: 600; }
     .wrap { padding: 0 20px; }
     .intro { padding: 48px 0 24px; }
     .intro::before { font-size: 180px; right: -30px; }
+    .intro-grid { flex-direction: column; align-items: flex-start; gap: 8px; }
+    .avatar-wrap { width: 150px; order: -1; align-self: flex-end; margin-top: -34px; }
     .intro h1 { font-size: 40px; }
     .lede { font-size: 16px; }
     .section { padding: 40px 0; }


### PR DESCRIPTION
## Summary
- **Animated student avatar** in the hero (hand-drawn inline SVG, no images): waving arm, blinking eyes, gentle head tilt, "hi!" speech bubble, graduation cap with gold tassel. The sweater picks up the theme accent so it recolours in dark mode; all motion honours `prefers-reduced-motion`.
- **Digital Brain — Personal Life OS** added to Selected Projects with visible `Live ↗` / `GitHub ↗` links and a hover-reveal **"Open live demo →"** pill linking to https://brain.madebycv.in.
- **Stack icons on every tech chip** (Python, FastAPI, LangGraph, Claude, PostgreSQL, Docker, Next.js, TypeScript, Supabase, Tailwind, Ollama, Vercel, Gemini, Firebase, BigQuery, PyTorch, …) via Simple Icons CDN rendered through CSS masks, so they inherit the chip colour and adapt to both themes. Chips without a brand icon (FHIR, Cloud Run, GPT-4o-mini, Diffusion Models, ControlNet) stay text-only.

## Test plan
- [x] Light + dark themes, desktop and 375px mobile, zero console errors, zero failed network requests
- [ ] After merge: check avatar animation and chip icons on the live site