### PR TITLE
Add waving student avatar, Digital Brain project, and stack icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,12 +38,54 @@
 
         <section id="intro" class="intro">
             <p class="status"><span class="dot"></span>Currently — LLM Research Engineer&nbsp;@&nbsp;Predii</p>
+            <div class="intro-grid">
+            <div class="intro-text">
             <h1>C. Viswanath</h1>
             <p class="lede">
                 LLM Research Engineer at <a href="https://www.predii.com" target="_blank" rel="noopener">Predii</a> and
                 MS&nbsp;by&nbsp;Research student at <a href="https://www.iiitb.ac.in" target="_blank" rel="noopener">IIIT Bangalore</a>.
                 I work on multilingual and agentic language models — currently on vision-LLM extraction, retrieval systems, and the mechanistic evaluation of <em class="accent-em">cultural understanding</em> in LLMs.
             </p>
+            </div>
+            <div class="avatar-wrap" aria-hidden="false">
+                <svg class="avatar" viewBox="0 0 240 250" role="img" aria-label="Cartoon student character waving hi">
+                    <g class="bubble">
+                        <rect x="158" y="14" rx="15" ry="15" width="66" height="38" class="bubble-bg"/>
+                        <path d="M176 51 l5 13 11-11 z" class="bubble-bg"/>
+                        <text x="191" y="40" class="bubble-text">hi!</text>
+                    </g>
+                    <g class="arm-wave">
+                        <path d="M150 162 Q176 148 184 122" class="sleeve"/>
+                        <circle cx="185" cy="114" r="10" class="skin"/>
+                    </g>
+                    <path d="M72 212 q0 -54 48 -54 q48 0 48 54 z" class="sweater"/>
+                    <path d="M86 172 q-14 18 -9 34" class="sleeve"/>
+                    <circle cx="79" cy="209" r="9" class="skin"/>
+                    <rect x="108" y="140" width="24" height="16" rx="7" class="skin"/>
+                    <g class="head">
+                        <circle cx="76" cy="106" r="7" class="skin"/>
+                        <circle cx="164" cy="106" r="7" class="skin"/>
+                        <circle cx="120" cy="102" r="44" class="skin"/>
+                        <path d="M76 98 q2 -46 44 -46 q42 0 44 46 q-7 -20 -22 -24 q5 8 3 13 q-11 -15 -35 -13 q-26 2 -34 24 z" class="hair"/>
+                        <circle cx="103" cy="108" r="13" class="glass"/>
+                        <circle cx="137" cy="108" r="13" class="glass"/>
+                        <path d="M116 108 h8" class="glass"/>
+                        <circle cx="103" cy="108" r="3.4" class="eye"/>
+                        <circle cx="137" cy="108" r="3.4" class="eye"/>
+                        <path d="M108 128 q12 10 24 0" class="smile"/>
+                        <ellipse cx="90" cy="124" rx="5" ry="3" class="blush"/>
+                        <ellipse cx="150" cy="124" rx="5" ry="3" class="blush"/>
+                        <g class="cap">
+                            <path d="M120 34 L174 56 L120 78 L66 56 Z" class="cap-top"/>
+                            <path d="M98 64 v14 q22 11 44 0 v-14" class="cap-base"/>
+                            <path d="M174 56 v24" class="tassel-string"/>
+                            <circle cx="174" cy="84" r="5" class="tassel"/>
+                        </g>
+                    </g>
+                    <ellipse cx="120" cy="222" rx="58" ry="7" class="ground"/>
+                </svg>
+            </div>
+            </div>
             <ul class="meta">
                 <li>Bangalore, IN</li>
                 <li><a href="mailto:cvishwanath1417@gmail.com">cvishwanath1417@gmail.com</a></li>
@@ -168,7 +210,43 @@
                         <li>Twelve-microservice LangGraph orchestrator with 92% eval pass rate, DEPA-style consent gate, PII encryption and full audit trail on GKE.</li>
                         <li>Stateful conversations handling interruptions, context switches and database-backed scheme validation in real time.</li>
                     </ul>
-                    <p class="tags"><span>Python</span><span>FastAPI</span><span>LangGraph</span><span>Claude Sonnet</span><span>PostgreSQL</span><span>Docker</span><span>GKE</span></p>
+                    <p class="tags">
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/python')"></i>Python</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/fastapi')"></i>FastAPI</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/langgraph')"></i>LangGraph</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/claude')"></i>Claude Sonnet</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/postgresql')"></i>PostgreSQL</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/docker')"></i>Docker</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/googlecloud')"></i>GKE</span>
+                    </p>
+                </article>
+
+                <article class="entry card">
+                    <a class="card-cta" href="https://brain.madebycv.in" target="_blank" rel="noopener">Open live demo →</a>
+                    <div class="entry-head">
+                        <div>
+                            <h3>Digital Brain — Personal Life OS</h3>
+                            <p class="org">Routine, habits, work board, journal &amp; meditation in one place</p>
+                        </div>
+                        <span class="date">
+                            <a href="https://brain.madebycv.in" target="_blank" rel="noopener">Live&nbsp;↗</a> · <a href="https://github.com/c-viswanath/digital-brain" target="_blank" rel="noopener">GitHub&nbsp;↗</a>
+                        </span>
+                    </div>
+                    <ul>
+                        <li>Single-user "life OS" — daily routine, habit streaks, kanban work board, journal, meditation and discipline log, with Google Calendar sync.</li>
+                        <li>Next.js 16 + Supabase (Postgres, row-level security, auth) PWA deployed on Vercel at <a href="https://brain.madebycv.in" target="_blank" rel="noopener">brain.madebycv.in</a>.</li>
+                        <li>LLM-powered dynamic greeting and accountability nudges via GPT-4o-mini, with a local Ollama fallback for dev.</li>
+                    </ul>
+                    <p class="tags">
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/nextdotjs')"></i>Next.js</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/typescript')"></i>TypeScript</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/supabase')"></i>Supabase</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/tailwindcss')"></i>Tailwind v4</span>
+                        <span>GPT-4o-mini</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/ollama')"></i>Ollama</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/vercel')"></i>Vercel</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/googlecalendar')"></i>Google Calendar</span>
+                    </p>
                 </article>
 
                 <article class="entry card">
@@ -184,7 +262,14 @@
                         <li>Integrated EHR/EMR devices via REST and FHIR pipelines for real-time data ingestion on GCP.</li>
                         <li>HIPAA-compliant BigQuery and Firebase schemas with field-level encryption for sensitive EHR records.</li>
                     </ul>
-                    <p class="tags"><span>Gemini API</span><span>GCP</span><span>Cloud Run</span><span>Firebase</span><span>BigQuery</span><span>FHIR</span></p>
+                    <p class="tags">
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/googlegemini')"></i>Gemini API</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/googlecloud')"></i>GCP</span>
+                        <span>Cloud Run</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/firebase')"></i>Firebase</span>
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/googlebigquery')"></i>BigQuery</span>
+                        <span>FHIR</span>
+                    </p>
                 </article>
 
                 <article class="entry card">
@@ -201,7 +286,11 @@
                         <li>Enforces explicit colour palettes in diffusion outputs by encoding dominant CIELAB colours as conditioning maps.</li>
                         <li>Improved colour fidelity without sacrificing visual quality — useful for product photography.</li>
                     </ul>
-                    <p class="tags"><span>PyTorch</span><span>Diffusion Models</span><span>ControlNet</span></p>
+                    <p class="tags">
+                        <span><i class="ti" style="--i:url('https://cdn.simpleicons.org/pytorch')"></i>PyTorch</span>
+                        <span>Diffusion Models</span>
+                        <span>ControlNet</span>
+                    </p>
                 </article>
 
             </div>

--- a/style.css
+++ b/style.css
@@ -231,6 +231,14 @@ a {
     100% { box-shadow: 0 0 0 0 transparent; }
 }
 
+.intro-grid {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 28px;
+}
+.intro-text { flex: 1; min-width: 0; }
+
 .intro h1 {
     font-family: var(--serif);
     font-weight: 400;
@@ -238,6 +246,80 @@ a {
     line-height: 1.05;
     letter-spacing: -.01em;
     margin-bottom: 20px;
+}
+
+/* ---------- Avatar ---------- */
+.avatar-wrap {
+    flex-shrink: 0;
+    width: 200px;
+}
+.avatar { width: 100%; height: auto; display: block; }
+
+.avatar .skin { fill: #E0A971; }
+.avatar .hair { fill: #241C14; }
+.avatar .sweater { fill: var(--accent); }
+.avatar .sleeve {
+    fill: none;
+    stroke: var(--accent);
+    stroke-width: 14;
+    stroke-linecap: round;
+}
+.avatar .glass {
+    fill: rgba(255, 255, 255, .16);
+    stroke: var(--text);
+    stroke-width: 2.5;
+}
+.avatar .eye { fill: #1A1A1A; transform-box: fill-box; transform-origin: center; }
+[data-theme="dark"] .avatar .eye { fill: #14140F; }
+.avatar .smile {
+    fill: none;
+    stroke: #8C5A33;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+}
+.avatar .blush { fill: rgba(214, 108, 91, .35); }
+.avatar .cap-top { fill: #23231E; stroke: var(--rule); stroke-width: 1; }
+.avatar .cap-base { fill: #2E2E27; }
+.avatar .tassel-string { stroke: #D9A93F; stroke-width: 2; fill: none; }
+.avatar .tassel { fill: #D9A93F; }
+.avatar .ground { fill: rgba(0, 0, 0, .08); }
+[data-theme="dark"] .avatar .ground { fill: rgba(0, 0, 0, .35); }
+.avatar .bubble-bg { fill: var(--surface); stroke: var(--rule); stroke-width: 1.5; }
+.avatar .bubble-text {
+    font-family: var(--mono);
+    font-size: 19px;
+    fill: var(--accent);
+    text-anchor: middle;
+}
+
+.avatar .arm-wave {
+    transform-origin: 150px 160px;
+    animation: wave 1.9s ease-in-out infinite;
+}
+@keyframes wave {
+    0%, 100% { transform: rotate(10deg); }
+    50% { transform: rotate(-16deg); }
+}
+.avatar .head {
+    transform-origin: 120px 148px;
+    animation: head-tilt 5.6s ease-in-out infinite;
+}
+@keyframes head-tilt {
+    0%, 100% { transform: rotate(-1.6deg); }
+    50% { transform: rotate(2.2deg); }
+}
+.avatar .eye { animation: blink 4.4s infinite; }
+@keyframes blink {
+    0%, 91%, 96%, 100% { transform: scaleY(1); }
+    93.5% { transform: scaleY(.08); }
+}
+.avatar .bubble {
+    transform-origin: 190px 44px;
+    animation: bubble-bob 1.9s ease-in-out infinite;
+}
+@keyframes bubble-bob {
+    0%, 100% { transform: translateY(0) scale(1); }
+    50% { transform: translateY(-4px) scale(1.05); }
 }
 .lede {
     font-size: 18px;
@@ -423,6 +505,9 @@ main.wrap { counter-reset: sec; }
     margin-top: 14px;
 }
 .tags span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     font-family: var(--mono);
     font-size: 11px;
     letter-spacing: .01em;
@@ -433,9 +518,43 @@ main.wrap { counter-reset: sec; }
     padding: 3px 10px;
     transition: color .2s ease, border-color .2s ease;
 }
+.tags .ti {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+    background-color: currentColor;
+    -webkit-mask: var(--i) center / contain no-repeat;
+    mask: var(--i) center / contain no-repeat;
+}
 .cards .entry.card:hover .tags span {
     color: var(--text);
     border-color: color-mix(in oklab, var(--accent) 30%, var(--rule));
+}
+
+/* Hover CTA (live demo) */
+.card-cta {
+    position: absolute;
+    right: 20px;
+    bottom: 20px;
+    z-index: 2;
+    font-family: var(--mono);
+    font-size: 12px;
+    padding: 7px 14px;
+    border-radius: 999px;
+    background: var(--accent);
+    color: var(--bg);
+    opacity: 0;
+    transform: translateY(8px);
+    pointer-events: none;
+    transition: opacity .25s ease, transform .25s cubic-bezier(.2, .8, .3, 1);
+    box-shadow: 0 10px 24px -12px var(--glow);
+}
+.cards .entry.card:hover .card-cta,
+.card-cta:focus-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
 }
 
 .coursework {
@@ -528,6 +647,8 @@ ul.plain li strong { font-weight: 600; }
     .wrap { padding: 0 20px; }
     .intro { padding: 48px 0 24px; }
     .intro::before { font-size: 180px; right: -30px; }
+    .intro-grid { flex-direction: column; align-items: flex-start; gap: 8px; }
+    .avatar-wrap { width: 150px; order: -1; align-self: flex-end; margin-top: -34px; }
     .intro h1 { font-size: 40px; }
     .lede { font-size: 16px; }
     .section { padding: 40px 0; }


### PR DESCRIPTION
## Summary
- **Animated student avatar** in the hero (hand-drawn inline SVG, no images): waving arm, blinking eyes, gentle head tilt, "hi!" speech bubble, graduation cap with gold tassel. The sweater picks up the theme accent so it recolours in dark mode; all motion honours `prefers-reduced-motion`.
- **Digital Brain — Personal Life OS** added to Selected Projects with visible `Live ↗` / `GitHub ↗` links and a hover-reveal **"Open live demo →"** pill linking to https://brain.madebycv.in.
- **Stack icons on every tech chip** via Simple Icons CDN rendered through CSS masks, so they inherit the chip colour and adapt to both themes. Chips without a brand icon (FHIR, Cloud Run, GPT-4o-mini, Diffusion Models, ControlNet) stay text-only.

Supersedes #4 (same change, rebased onto current main).

## Test plan
- [x] Light + dark themes, desktop and 375px mobile, zero console errors, zero failed network requests
- [ ] After merge: check avatar animation and chip icons on the live site